### PR TITLE
Change mesh virtual services to accept x-variant-id header value as b…

### DIFF
--- a/src/templates/virtual_services-mesh.ctmpl
+++ b/src/templates/virtual_services-mesh.ctmpl
@@ -26,7 +26,7 @@ spec:
         -
           headers:
             x-variant-id:
-              exact: {{ .Key }}
+              regex: ({{ .Key }}|{{ .Key |toLower }})
       route:
         -
           destination:

--- a/test/expected_outputs/green-proof02/virtual_services-mesh.rendered
+++ b/test/expected_outputs/green-proof02/virtual_services-mesh.rendered
@@ -35,7 +35,7 @@ spec:
         -
           headers:
             x-variant-id:
-              exact: OPS-3353
+              regex: (OPS-3353|ops-3353)
       route:
         -
           destination:

--- a/test/expected_outputs/saturn-green-proof02/virtual_services-mesh.rendered
+++ b/test/expected_outputs/saturn-green-proof02/virtual_services-mesh.rendered
@@ -35,7 +35,7 @@ spec:
         -
           headers:
             x-variant-id:
-              exact: OPS-3353
+              regex: (OPS-3353|ops-3353)
       route:
         -
           destination:
@@ -69,7 +69,7 @@ spec:
         -
           headers:
             x-variant-id:
-              exact: OPS-335
+              regex: (OPS-335|ops-335)
       route:
         -
           destination:


### PR DESCRIPTION
…oth uppercase and lowercase, in line with the ingress virtual service definitions